### PR TITLE
Mudança na versão do Rails (alteração no Gemfile)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,12 @@
 source 'http://rubygems.org'
 
-gem 'rails', '3.1.0.rc4'
+gem 'rails', '3.1.0.rc5'
 gem 'devise'
 gem 'mysql2'
 gem 'sass'
 gem 'coffee-script'
 gem 'uglifier'
 gem 'jquery-rails'
-gem 'sprockets', '2.0.0.beta.10'
 gem 'RedCloth'
 
 group :development,:test do


### PR DESCRIPTION
Mudando o Rails para a versão 3.1.0.rc5 e tirando o sprockets do Gemfile.
