### PR TITLE
Avoid installing ruby-debug on travis-ci.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,11 +19,13 @@ group :development,:test do
   gem 'launchy',        '2.0.5'
   gem "simplecov",      '0.5.3'
 
-  platforms :mri_18 do
-    gem "ruby-debug",   '0.10.4'
-  end
-  platforms :mri_19 do
-    gem "ruby-debug19", '0.11.6', :require => 'ruby-debug'
+  unless ENV["CI"]
+    platforms :mri_18 do
+      gem "ruby-debug",   '0.10.4'
+    end
+    platforms :mri_19 do
+      gem "ruby-debug19", '0.11.6', :require => 'ruby-debug'
+    end
   end
 end
 


### PR DESCRIPTION
See "Exclude non-essential gems" in [the Ruby guide](http://about.travis-ci.org/docs/user/languages/ruby/) to understand why.
